### PR TITLE
Improve error handling and status

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,32 +4,33 @@ set -euo pipefail
 
 npm install -g  backstopjs
 
+COMMAND=$1
 STATE=failure
 GITHUB_API_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}"
 
-if backstop $1; then
-  STATE=success
-fi
+STATUS_DATA="{\"state\": \"pending\", \"description\": \"${COMMAND}\", \"context\": \"Visual regression test\"}"
+curl --fail -X POST --user ":${GITHUB_TOKEN}" "${GITHUB_API_URL}" --data "${STATUS_DATA}"
 
-if [ "$1" == "test" ]; then
+backstop "${COMMAND}" || true
+
+if [ "${COMMAND}" == "test" ]; then
     echo "$BACKSTORE_KEY" > /tmp/key
     chmod go= /tmp/key
 
     REFERENCE_IMAGES=$(jq -r .paths.bitmaps_reference backstop.json)
     TEST_IMAGES=$(jq -r .paths.bitmaps_test backstop.json)
     HTML_REPORT=$(jq -r .paths.html_report backstop.json)
-    SHA=$(echo $GITHUB_REPOSITORY:$HEAD_SHA | sha1sum - | cut -d" " -f 1)
+    SHA=$(echo "${GITHUB_REPOSITORY}:${HEAD_SHA}" | sha1sum - | cut -d" " -f 1)
+    ERRORS=$(sed -zE 's/.*errors="([0-9]+)".*/\1/' backstop_data/ci_report/xunit.xml)
 
-    rsync -e 'ssh -i /tmp/key -p 1984 -o StrictHostKeyChecking=no' -r ${REFERENCE_IMAGES} ${TEST_IMAGES} ${HTML_REPORT} store@backstore.reload.dk:backstore/${SHA}/
+    if [[ "${ERRORS}" == "0" ]]; then
+        STATE=success
+    fi
 
-    BACKSTORE_URL=https://backstore.reload.dk/${SHA}/$(basename $HTML_REPORT)
+    rsync -e 'ssh -i /tmp/key -p 1984 -o StrictHostKeyChecking=no' -r "${REFERENCE_IMAGES}" "${TEST_IMAGES}" "${HTML_REPORT}" "store@backstore.reload.dk:backstore/${SHA}/"
+
+    BACKSTORE_URL=https://backstore.reload.dk/${SHA}/$(basename "${HTML_REPORT}")
 
     STATUS_DATA="{\"state\": \"${STATE}\", \"description\": \"Report\", \"context\": \"Visual regression test\", \"target_url\": \"${BACKSTORE_URL}\"}"
     curl --fail --silent -X POST --user ":${GITHUB_TOKEN}" "${GITHUB_API_URL}" --data "${STATUS_DATA}"
 fi
-
-if [ "$STATE" == "success" ]; then
-  exit
-fi
-
-exit 1


### PR DESCRIPTION
Ignore errors from running the backstop command itself, since we cannot distinguish between errors stemming from visual diffs and errors stemming from actual execution errors.

Instead, we discover the number of visual diff errors from the `xunit.xml` output.

Also, we'll let the action post a pending state when running.

And we fix some style issues identified by `shellcheck`.

Users of the action must add the GitHub token to the reference step, but we only have one repository using the `no-container` branch yet. I have made a branch named `v2` (based on `no-container`). This will be the future name for the improved visual test stuff.